### PR TITLE
Use the actual version than inferred version for dart-sass-embedded

### DIFF
--- a/dart-sass-embedded.rb
+++ b/dart-sass-embedded.rb
@@ -41,9 +41,7 @@ class DartSassEmbedded < Formula
   end
 
   def _version
-    # The next line is current broken: https://github.com/sass/dart-sass-embedded/pull/121
-    # @_version ||= YAML.safe_load(File.read("pubspec.yaml"))["version"]
-    @_version ||= version
+    @_version ||= YAML.safe_load(File.read("pubspec.yaml"))["version"]
   end
 
   def _protocol_version


### PR DESCRIPTION
This the inferred version was used because ruby was not able to parse the yaml in 1.56.1, but with the updated yaml file in 1.56.2, it should be okay now.